### PR TITLE
handbook/kde: Mention sysctl.conf

### DIFF
--- a/documentation/content/en/books/handbook/desktop/_index.adoc
+++ b/documentation/content/en/books/handbook/desktop/_index.adoc
@@ -151,12 +151,14 @@ Enable D-BUS service in `/etc/rc.conf` to start at system boot:
 # sysrc dbus_enable="YES"
 ....
 
-To increase messages size execute:
+To help the desktop's performance, increase message sizes for DBus' inter-process communication.
+
+Edit the `/etc/sysctl.conf` with an editor of choice, then, add the following lines:
 
 [source,shell]
 ....
-sysctl net.local.stream.recvspace=65536
-sysctl net.local.stream.sendspace=65536
+net.local.stream.recvspace=65536
+net.local.stream.sendspace=65536
 ....
 
 [[kde-start]]


### PR DESCRIPTION
Update handbook entry for DBus message sizes tweak to sysctl to allow it to persist after reboot